### PR TITLE
make A1Notation immutable

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -357,12 +357,13 @@ const toStringTestCases: ToStringTestCase[] = [
 
 for (const { input, output } of toStringTestCases) {
     Deno.test(`A1Notation.toString(${JSON.stringify(input)})`, () => {
-        const a1 = new A1Notation();
-        a1.sheetName = input.sheetName;
-        a1.top = input.top;
-        a1.bottom = input.bottom;
-        a1.left = input.left;
-        a1.right = input.right;
+        const a1 = new A1Notation(
+            input.sheetName,
+            input.left,
+            input.top,
+            input.right,
+            input.bottom,
+        );
         assertEquals(`${a1}`, output);
     });
 }

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -46,6 +46,31 @@ Deno.test("constructor: sheetName, left, top, right, bottom", () => {
     assertEquals(a1.bottom, 4);
 });
 
+Deno.test("constructor: invalid parameter", () => {
+    assertThrows(() => {
+        // sheetName must not be an empty string
+        new A1Notation("");
+    });
+    assertThrows(() => {
+        new A1Notation(undefined, 0);
+    });
+    assertThrows(() => {
+        new A1Notation(undefined, 1, 0);
+    });
+    assertThrows(() => {
+        new A1Notation(undefined, 1, 1, 0);
+    });
+    assertThrows(() => {
+        new A1Notation(undefined, 1, 1, 1, 0);
+    });
+    assertThrows(() => {
+        new A1Notation(undefined, 2, undefined, 1);
+    });
+    assertThrows(() => {
+        new A1Notation(undefined, undefined, 2, undefined, 1);
+    });
+});
+
 interface ParseTestCase {
     input: string;
     output: {

--- a/mod.ts
+++ b/mod.ts
@@ -12,7 +12,7 @@ export class A1Notation {
    * @type {?string}
    * @memberof A1Notation
    */
-  sheetName?: string;
+  readonly sheetName?: string;
 
   /**
    * The left column number of the range. Optional.
@@ -20,7 +20,7 @@ export class A1Notation {
    * @type {?number}
    * @memberof A1Notation
    */
-  left?: number;
+  readonly left?: number;
 
   /**
    * The top row number of the range. Optional.
@@ -28,7 +28,7 @@ export class A1Notation {
    * @type {?number}
    * @memberof A1Notation
    */
-  top?: number;
+  readonly top?: number;
 
   /**
    * The right column number of the range. Optional.
@@ -36,7 +36,7 @@ export class A1Notation {
    * @type {?number}
    * @memberof A1Notation
    */
-  right?: number;
+  readonly right?: number;
 
   /**
    * The bottom row number of the range. Optional.
@@ -44,7 +44,7 @@ export class A1Notation {
    * @type {?number}
    * @memberof A1Notation
    */
-  bottom?: number;
+  readonly bottom?: number;
 
   constructor(
     sheetName?: string,
@@ -89,22 +89,22 @@ export class A1Notation {
   static parse(s: string): A1Notation {
     const parser = new Parser(s);
     const { sheetName, cell1, cell2 } = parser.parse();
+    let left: number | undefined;
+    let top: number | undefined;
+    let right: number | undefined;
+    let bottom: number | undefined;
 
-    const a1 = new A1Notation();
-    if (sheetName) {
-      a1.sheetName = sheetName;
-    }
     if (cell1) {
       const { row, col } = parseCell(cell1);
-      a1.top = row;
-      a1.left = col;
+      top = row;
+      left = col;
     }
     if (cell2) {
       const { row, col } = parseCell(cell2);
-      a1.bottom = row;
-      a1.right = col;
+      bottom = row;
+      right = col;
     }
-    return a1;
+    return new A1Notation(sheetName, left, top, right, bottom);
   }
 
   /**

--- a/mod.ts
+++ b/mod.ts
@@ -53,15 +53,37 @@ export class A1Notation {
     right?: number,
     bottom?: number,
   ) {
+    if (sheetName === "") {
+      throw new Error("sheetName must not be an empty string");
+    }
+    if (left !== undefined && left <= 0) {
+      throw new Error("left must be greater than 0");
+    }
+    if (top !== undefined && top <= 0) {
+      throw new Error("top must be greater than 0");
+    }
+    if (right !== undefined && right <= 0) {
+      throw new Error("right must be greater than 0");
+    }
+    if (bottom !== undefined && bottom <= 0) {
+      throw new Error("bottom must be greater than 0");
+    }
+    if (right === undefined && bottom === undefined) {
+      right = left;
+      bottom = top;
+    }
+    if (top !== undefined && bottom !== undefined && top > bottom) {
+      throw new Error("top must be less than or equal to bottom");
+    }
+    if (left !== undefined && right !== undefined && left > right) {
+      throw new Error("left must be less than or equal to right");
+    }
+
     this.sheetName = sheetName;
     this.left = left;
     this.top = top;
     this.right = right;
     this.bottom = bottom;
-    if (right === undefined && bottom === undefined) {
-      this.right = left;
-      this.bottom = top;
-    }
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the `A1Notation` class by making key properties read-only, ensuring they cannot be modified after instantiation.
	- Streamlined the object creation process for better efficiency and clarity.
	
These improvements promote safer and more predictable usage of the `A1Notation` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->